### PR TITLE
FRI-27 Consume Classification status via JMS

### DIFF
--- a/src/main/java/org/snomed/otf/reasoner/server/pojo/ClassificationStatusAndMessage.java
+++ b/src/main/java/org/snomed/otf/reasoner/server/pojo/ClassificationStatusAndMessage.java
@@ -4,6 +4,7 @@ public class ClassificationStatusAndMessage {
 
 	private ClassificationStatus status;
 	private String statusMessage;
+	private String id;
 
 	public ClassificationStatusAndMessage() {
 	}
@@ -15,6 +16,12 @@ public class ClassificationStatusAndMessage {
 	public ClassificationStatusAndMessage(ClassificationStatus status, String statusMessage) {
 		this.status = status;
 		this.statusMessage = statusMessage;
+	}
+
+	public ClassificationStatusAndMessage(ClassificationStatus status, String statusMessage, String id) {
+		this.status = status;
+		this.statusMessage = statusMessage;
+		this.id = id;
 	}
 
 	public ClassificationStatus getStatus() {
@@ -31,6 +38,14 @@ public class ClassificationStatusAndMessage {
 
 	public void setStatusMessage(String statusMessage) {
 		this.statusMessage = statusMessage;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	@Override

--- a/src/main/java/org/snomed/otf/reasoner/server/service/ClassificationJobManager.java
+++ b/src/main/java/org/snomed/otf/reasoner/server/service/ClassificationJobManager.java
@@ -130,7 +130,7 @@ public class ClassificationJobManager {
 	}
 
 	private void classify(Classification classification, Consumer<ClassificationStatusAndMessage> statusConsumer) {
-		statusConsumer.accept(new ClassificationStatusAndMessage(ClassificationStatus.RUNNING));
+		statusConsumer.accept(new ClassificationStatusAndMessage(ClassificationStatus.RUNNING, null, classification.getClassificationId()));
 		logger.info("Running classification {}, branch {}", classification.getClassificationId(), classification.getBranch());
 
 		Set<String> previousPackages = new HashSet<>();
@@ -159,12 +159,12 @@ public class ClassificationJobManager {
 						classification.getReasonerId(),
 						outputOntologyFileForDebug);
 			}
-			statusConsumer.accept(new ClassificationStatusAndMessage(ClassificationStatus.COMPLETED));
+			statusConsumer.accept(new ClassificationStatusAndMessage(ClassificationStatus.COMPLETED, null, classification.getClassificationId()));
 			logger.info("Classification complete {}, branch {}. Results written to {}", classification.getClassificationId(), classification.getBranch(), resultsPath);
 
 		} catch (ReasonerServiceException | IOException e) {
 			logger.error("Classification failed {}, branch {}. ", e.getMessage(), classification.getClassificationId(), classification.getBranch(), e);
-			statusConsumer.accept(new ClassificationStatusAndMessage(ClassificationStatus.FAILED, e.getMessage()));
+			statusConsumer.accept(new ClassificationStatusAndMessage(ClassificationStatus.FAILED, e.getMessage(), classification.getClassificationId()));
 		} finally {
 			if (tempDeltaFile != null) {
 				tempDeltaFile.delete();


### PR DESCRIPTION
FRI-27 is concerned with updating Snowstorm to retrieve a Classification's status via JMS instead of HTTP. 

This PR changes Classification Service to write the Classification's id to the queue such that it can be identified from Snowstorm. 